### PR TITLE
feat: add consensus filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.0.0"
 edition = "2021"
 
 [features]
-default = ["serde"]
+default = ["serde", "base64"]
 cosmwasm = ["cosmwasm-schema", "cosmwasm-std"]
 test-utils = []
 
 [dependencies]
-base64 = "0.22.1"
+base64 = { version = "0.22.1", optional = true }
 cosmwasm-schema = { version = "1.5.5", optional = true }
 cosmwasm-std = { version = "1.5.5", optional = true }
 cw-storage-plus = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ cosmwasm = ["cosmwasm-schema", "cosmwasm-std"]
 test-utils = []
 
 [dependencies]
+base64 = "0.22.1"
 cosmwasm-schema = { version = "1.5.5", optional = true }
 cosmwasm-std = { version = "1.5.5", optional = true }
 cw-storage-plus = "1.2.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use hex::FromHexError;
 use thiserror::Error;
 use vrf_rs::error::VrfError;
 
@@ -5,6 +6,9 @@ use vrf_rs::error::VrfError;
 #[derive(Error, Debug, PartialEq)]
 #[cfg_attr(feature = "test-utils", derive(Clone))]
 pub enum Error {
+    #[error(transparent)]
+    FromHexError(#[from] FromHexError),
+
     #[cfg(not(feature = "test-utils"))]
     #[error(transparent)]
     Prove(#[from] VrfError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,10 @@ use vrf_rs::error::VrfError;
 #[cfg_attr(feature = "test-utils", derive(Clone))]
 pub enum Error {
     #[error(transparent)]
-    FromHexError(#[from] FromHexError),
+    FromHex(#[from] FromHexError),
+
+    #[error(transparent)]
+    FromBase64(#[from] base64::DecodeError),
 
     #[cfg(not(feature = "test-utils"))]
     #[error(transparent)]

--- a/src/msgs/data_requests/execute_tests.rs
+++ b/src/msgs/data_requests/execute_tests.rs
@@ -39,6 +39,11 @@ fn json_post_request() {
     let tally_inputs: Bytes = "tally_inputs".as_bytes().into();
 
     #[cfg(not(feature = "cosmwasm"))]
+    let consensus_filter = "consensus_filter".to_string();
+    #[cfg(feature = "cosmwasm")]
+    let consensus_filter: Bytes = "consensus_filter".as_bytes().into();
+
+    #[cfg(not(feature = "cosmwasm"))]
     let gas_price = "100".to_string();
     #[cfg(feature = "cosmwasm")]
     let gas_price: U128 = 100u128.into();
@@ -70,6 +75,7 @@ fn json_post_request() {
         tally_binary_id:    "tally_binary_id".to_string(),
         tally_inputs:       tally_inputs.clone(),
         replication_factor: 1,
+        consensus_filter:   consensus_filter.clone(),
         gas_price:          gas_price.clone(),
         gas_limit:          gas_limit.clone(),
         memo:               memo.clone(),
@@ -83,6 +89,7 @@ fn json_post_request() {
           "tally_binary_id": "tally_binary_id",
           "tally_inputs": tally_inputs,
           "replication_factor": 1,
+          "consensus_filter": consensus_filter,
           "gas_price": gas_price,
           "gas_limit": gas_limit,
           "memo": memo

--- a/src/msgs/data_requests/types.rs
+++ b/src/msgs/data_requests/types.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "cosmwasm"))]
 use base64::{prelude::BASE64_STANDARD, Engine};
 #[cfg(feature = "cosmwasm")]
 use cw_storage_plus::{Key, Prefixer, PrimaryKey};
@@ -203,13 +204,13 @@ pub struct RevealBody {
     pub reveal:    Bytes,
 }
 
-impl HashSelf for RevealBody {
-    fn hash(&self) -> Hash {
+impl TryHashSelf for RevealBody {
+    fn try_hash(&self) -> Result<Hash> {
         let mut reveal_hasher = Keccak256::new();
         #[cfg(feature = "cosmwasm")]
-        reveal_hasher.update(&self.reveal.to_base64());
+        reveal_hasher.update(self.reveal.as_slice());
         #[cfg(not(feature = "cosmwasm"))]
-        reveal_hasher.update(&self.reveal);
+        reveal_hasher.update(BASE64_STANDARD.decode(&self.reveal)?);
         let reveal_hash = reveal_hasher.finalize();
 
         let mut hasher = Keccak256::new();
@@ -225,7 +226,8 @@ impl HashSelf for RevealBody {
                 .to_be_bytes(),
         );
         hasher.update(reveal_hash);
-        hasher.finalize().into()
+
+        Ok(hasher.finalize().into())
     }
 }
 
@@ -250,30 +252,30 @@ impl TryHashSelf for PostDataRequestArgs {
         // hash non-fixed-length inputs
         let mut dr_inputs_hasher = Keccak256::new();
         #[cfg(feature = "cosmwasm")]
-        dr_inputs_hasher.update(&self.dr_inputs.to_base64());
+        dr_inputs_hasher.update(self.dr_inputs.as_slice());
         #[cfg(not(feature = "cosmwasm"))]
-        dr_inputs_hasher.update(&self.dr_inputs);
+        dr_inputs_hasher.update(BASE64_STANDARD.decode(&self.dr_inputs)?);
         let dr_inputs_hash = dr_inputs_hasher.finalize();
 
         let mut tally_inputs_hasher = Keccak256::new();
         #[cfg(feature = "cosmwasm")]
-        tally_inputs_hasher.update(&self.tally_inputs.to_base64());
+        tally_inputs_hasher.update(self.tally_inputs.as_slice());
         #[cfg(not(feature = "cosmwasm"))]
-        tally_inputs_hasher.update(&self.tally_inputs);
+        tally_inputs_hasher.update(BASE64_STANDARD.decode(&self.tally_inputs)?);
         let tally_inputs_hash = tally_inputs_hasher.finalize();
 
         let mut consensus_filter_hasher = Keccak256::new();
         #[cfg(feature = "cosmwasm")]
-        consensus_filter_hasher.update(&self.consensus_filter.to_base64());
+        consensus_filter_hasher.update(self.consensus_filter.as_slice());
         #[cfg(not(feature = "cosmwasm"))]
-        consensus_filter_hasher.update(&self.consensus_filter);
+        consensus_filter_hasher.update(BASE64_STANDARD.decode(&self.consensus_filter)?);
         let consensus_filter_hash = consensus_filter_hasher.finalize();
 
         let mut memo_hasher = Keccak256::new();
         #[cfg(feature = "cosmwasm")]
-        memo_hasher.update(&self.memo.to_base64());
+        memo_hasher.update(self.memo.as_slice());
         #[cfg(not(feature = "cosmwasm"))]
-        memo_hasher.update(&self.memo);
+        memo_hasher.update(BASE64_STANDARD.decode(&self.memo)?);
         let memo_hash = memo_hasher.finalize();
 
         // hash data request

--- a/src/msgs/mod.rs
+++ b/src/msgs/mod.rs
@@ -3,7 +3,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 #[cfg(not(feature = "cosmwasm"))]
 use serde::{Deserialize, Serialize};
 
-use crate::types::*;
+use crate::{error::*, types::*};
 
 pub mod data_requests;
 pub mod owner;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
 use semver::Version;
 use sha3::{Digest, Keccak256};
 
+use crate::error::Result;
+
 #[cfg(feature = "cosmwasm")]
 pub(crate) type U128 = cosmwasm_std::Uint128;
 #[cfg(not(feature = "cosmwasm"))]
@@ -29,6 +31,10 @@ impl<const N: usize> ToHexStr for [u8; N] {
     fn to_hex(&self) -> String {
         hex::encode(self)
     }
+}
+
+pub trait TryHashSelf {
+    fn try_hash(&self) -> Result<Hash>;
 }
 
 pub trait HashSelf {


### PR DESCRIPTION
## Motivation

Previously, the filter was defined as the first item in the tally inputs. This approach was awkward and led to confusion, so we decided to define the filter as a separate field.

The main rationale behind this change are:
- Tally VMs do not require the filter input, making its inclusion unnecessary.
- It was often confusing to refer to it as "tally filtering" when it was not part of the tally VM execution.
- We have renamed it to "consensus filter" to better reflect its purpose.
- The consensus filter has its own decoding process, whereas the rest of the tally inputs can have custom encoding as specified by the user.

## Explanation of Changes

We are introducing a new data request field called consensus_filter.

## Related PRs and Issues

This PR will require a series of follow-up PRs in other repositories.