### PR TITLE
refactor: dr query returns options

### DIFF
--- a/src/msgs/data_requests/query.rs
+++ b/src/msgs/data_requests/query.rs
@@ -5,7 +5,7 @@ use super::*;
 #[cfg_attr(not(feature = "cosmwasm"), derive(Serialize))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub enum QueryMsg {
-    #[cfg_attr(feature = "cosmwasm", returns(DataRequest))]
+    #[cfg_attr(feature = "cosmwasm", returns(Option<DataRequest>))]
     GetDataRequest { dr_id: String },
     #[cfg_attr(feature = "cosmwasm",  returns(Option<String>))]
     GetDataRequestCommitment { dr_id: String, public_key: String },
@@ -15,7 +15,7 @@ pub enum QueryMsg {
     GetDataRequestReveal { dr_id: String, public_key: String },
     #[cfg_attr(feature = "cosmwasm",  returns(HashMap<String, RevealBody>))]
     GetDataRequestReveals { dr_id: String },
-    #[cfg_attr(feature = "cosmwasm", returns(DataResult))]
+    #[cfg_attr(feature = "cosmwasm", returns(Option<DataResult>))]
     GetDataResult { dr_id: String },
     #[cfg_attr(feature = "cosmwasm",  returns(Vec<DataRequest>))]
     GetDataRequestsByStatus {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

For consistency, since some did and some didn't.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

All queries that return a non-employable object now return an option of their type.
So if something returns a vec/map, we will return an empty version rather than null.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

All tests still pass.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
