### PR TITLE
ref(types): make U128 a string again

### DIFF
--- a/src/msgs/data_requests/execute_tests.rs
+++ b/src/msgs/data_requests/execute_tests.rs
@@ -44,12 +44,12 @@ fn json_post_request() {
     let consensus_filter: Bytes = "consensus_filter".as_bytes().into();
 
     #[cfg(not(feature = "cosmwasm"))]
-    let gas_price = 100;
+    let gas_price = "100".to_string();
     #[cfg(feature = "cosmwasm")]
     let gas_price: U128 = 100u128.into();
 
     #[cfg(not(feature = "cosmwasm"))]
-    let gas_limit = 100;
+    let gas_limit = "100".to_string();
     #[cfg(feature = "cosmwasm")]
     let gas_limit: U128 = 100u128.into();
 
@@ -69,16 +69,16 @@ fn json_post_request() {
     let payback_address: Bytes = "payback_address".as_bytes().into();
 
     let args = PostDataRequestArgs {
-        version: Version::new(1, 0, 0),
-        dr_binary_id: "dr_binary_id".to_string(),
-        dr_inputs: dr_inputs.clone(),
-        tally_binary_id: "tally_binary_id".to_string(),
-        tally_inputs: tally_inputs.clone(),
+        version:            Version::new(1, 0, 0),
+        dr_binary_id:       "dr_binary_id".to_string(),
+        dr_inputs:          dr_inputs.clone(),
+        tally_binary_id:    "tally_binary_id".to_string(),
+        tally_inputs:       tally_inputs.clone(),
         replication_factor: 1,
-        consensus_filter: consensus_filter.clone(),
-        gas_price,
-        gas_limit,
-        memo: memo.clone(),
+        consensus_filter:   consensus_filter.clone(),
+        gas_price:          gas_price.clone(),
+        gas_limit:          gas_limit.clone(),
+        memo:               memo.clone(),
     };
     let expected_json = json!({
       "post_data_request": {
@@ -110,7 +110,7 @@ fn json_post_request() {
 #[test]
 fn json_reveal_result() {
     #[cfg(not(feature = "cosmwasm"))]
-    let gas_used = 100;
+    let gas_used = "100".to_string();
     #[cfg(feature = "cosmwasm")]
     let gas_used: U128 = 100u128.into();
 
@@ -120,10 +120,10 @@ fn json_reveal_result() {
     let reveal: Bytes = "reveal".as_bytes().into();
 
     let reveal_body = RevealBody {
-        salt: "salt".to_string(),
+        salt:      "salt".to_string(),
         exit_code: 0,
-        gas_used,
-        reveal: reveal.clone(),
+        gas_used:  gas_used.clone(),
+        reveal:    reveal.clone(),
     };
     let expected_json = json!({
       "reveal_data_result": {

--- a/src/msgs/data_requests/sudo_tests.rs
+++ b/src/msgs/data_requests/sudo_tests.rs
@@ -14,7 +14,7 @@ fn json_post_result() {
     let result_bytes: Bytes = "result".as_bytes().into();
 
     #[cfg(not(feature = "cosmwasm"))]
-    let gas_used = 100;
+    let gas_used = "100".to_string();
     #[cfg(feature = "cosmwasm")]
     let gas_used: U128 = 100u128.into();
 
@@ -28,15 +28,15 @@ fn json_post_result() {
     #[cfg(feature = "cosmwasm")]
     let payback_address: Bytes = "payback_address".as_bytes().into();
     let result = DataResult {
-        version: Version::new(1, 0, 0),
-        dr_id: "dr_id".to_string(),
-        block_height: 100,
-        exit_code: 0,
-        gas_used,
-        result: result_bytes.clone(),
+        version:         Version::new(1, 0, 0),
+        dr_id:           "dr_id".to_string(),
+        block_height:    100,
+        exit_code:       0,
+        gas_used:        gas_used.clone(),
+        result:          result_bytes.clone(),
         payback_address: payback_address.clone(),
-        seda_payload: seda_payload.clone(),
-        consensus: false,
+        seda_payload:    seda_payload.clone(),
+        consensus:       false,
     };
     let expected_json = json!({
     "post_data_result": {

--- a/src/msgs/data_requests/types.rs
+++ b/src/msgs/data_requests/types.rs
@@ -157,7 +157,11 @@ impl TryHashSelf for DataResult {
         #[cfg(feature = "cosmwasm")]
         let gas_used = self.gas_used.to_be_bytes();
         #[cfg(not(feature = "cosmwasm"))]
-        let gas_used = self.gas_used.to_be_bytes();
+        let gas_used = self
+            .gas_used
+            .parse::<u128>()
+            .expect("gas used should be parseable to u128")
+            .to_be_bytes();
 
         let mut payback_hasher = Keccak256::new();
         #[cfg(feature = "cosmwasm")]
@@ -217,7 +221,12 @@ impl TryHashSelf for RevealBody {
         #[cfg(feature = "cosmwasm")]
         hasher.update(self.gas_used.to_be_bytes());
         #[cfg(not(feature = "cosmwasm"))]
-        hasher.update(self.gas_used.to_be_bytes());
+        hasher.update(
+            self.gas_used
+                .parse::<u128>()
+                .expect("`gas_used` should be parseable to u128")
+                .to_be_bytes(),
+        );
         hasher.update(reveal_hash);
 
         Ok(hasher.finalize().into())
@@ -286,11 +295,21 @@ impl TryHashSelf for PostDataRequestArgs {
         #[cfg(feature = "cosmwasm")]
         dr_hasher.update(self.gas_price.to_be_bytes());
         #[cfg(not(feature = "cosmwasm"))]
-        dr_hasher.update(self.gas_price.to_be_bytes());
+        dr_hasher.update(
+            self.gas_price
+                .parse::<u128>()
+                .expect("`gas_price` should be parseable to u128")
+                .to_be_bytes(),
+        );
         #[cfg(feature = "cosmwasm")]
         dr_hasher.update(self.gas_limit.to_be_bytes());
         #[cfg(not(feature = "cosmwasm"))]
-        dr_hasher.update(self.gas_limit.to_be_bytes());
+        dr_hasher.update(
+            self.gas_limit
+                .parse::<u128>()
+                .expect("`gas_limit` should be parseable to u128")
+                .to_be_bytes(),
+        );
         dr_hasher.update(memo_hash);
 
         Ok(dr_hasher.finalize().into())

--- a/src/msgs/staking/execute/withdraw.rs
+++ b/src/msgs/staking/execute/withdraw.rs
@@ -14,7 +14,13 @@ impl Execute {
     fn generate_hash(amount: U128, chain_id: &str, contract_addr: &str, sequence: u128) -> Hash {
         hash([
             "withdraw".as_bytes(),
+            #[cfg(feature = "cosmwasm")]
             &amount.to_be_bytes(),
+            #[cfg(not(feature = "cosmwasm"))]
+            &amount
+                .parse::<u128>()
+                .expect("`amount` should be parseable to u128")
+                .to_be_bytes(),
             chain_id.as_bytes(),
             contract_addr.as_bytes(),
             &sequence.to_be_bytes(),
@@ -32,7 +38,14 @@ impl VerifySelf for Execute {
     fn msg_hash(&self, chain_id: &str, contract_addr: &str, sequence: Self::Extra) -> Result<Hash> {
         Ok(hash([
             "withdraw".as_bytes(),
+            #[cfg(feature = "cosmwasm")]
             &self.amount.to_be_bytes(),
+            #[cfg(not(feature = "cosmwasm"))]
+            &self
+                .amount
+                .parse::<u128>()
+                .expect("`amount` should be parseable to u128")
+                .to_be_bytes(),
             chain_id.as_bytes(),
             contract_addr.as_bytes(),
             &sequence.to_be_bytes(),
@@ -68,7 +81,7 @@ impl Execute {
         contract_addr: &str,
         sequence: u128,
     ) -> ExecuteFactory {
-        let hash = Self::generate_hash(amount, chain_id, contract_addr, sequence);
+        let hash = Self::generate_hash(amount.clone(), chain_id, contract_addr, sequence);
         ExecuteFactory {
             public_key,
             amount,

--- a/src/msgs/staking/execute_tests.rs
+++ b/src/msgs/staking/execute_tests.rs
@@ -44,7 +44,7 @@ fn json_stake() {
 #[test]
 fn json_unstake() {
     #[cfg(not(feature = "cosmwasm"))]
-    let amount: U128 = 0;
+    let amount: U128 = "0".to_string();
     #[cfg(feature = "cosmwasm")]
     let amount: U128 = 0u128.into();
     let serialized = json!({
@@ -66,7 +66,7 @@ fn json_unstake() {
 #[test]
 fn json_withdraw() {
     #[cfg(not(feature = "cosmwasm"))]
-    let amount: U128 = 0;
+    let amount: U128 = "0".to_string();
     #[cfg(feature = "cosmwasm")]
     let amount: U128 = 0u128.into();
     let serialized = json!({

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,8 +12,10 @@ pub(crate) use verify_self::VerifySelf;
 
 #[cfg(feature = "cosmwasm")]
 pub(crate) type U128 = cosmwasm_std::Uint128;
+
+// Is required to be a String, JSON does not support u128 numbers
 #[cfg(not(feature = "cosmwasm"))]
-pub(crate) type U128 = u128;
+pub(crate) type U128 = String;
 
 pub fn serialize_as_str<S, V>(value: V, serializer: S) -> Result<S::Ok, S::Error>
 where


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The overlay node broke because u128 is not supported as a JSON type. It must be a string (added a comment for future references)

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Reverted changes to go back to a string instead of a u128

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

cargo test works
