### PR TITLE
Add commit and reveal check queries

### DIFF
--- a/crates/common/src/msgs/data_requests/query.rs
+++ b/crates/common/src/msgs/data_requests/query.rs
@@ -8,6 +8,15 @@ use super::types::*;
 #[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub enum QueryMsg {
+    #[cfg_attr(feature = "cosmwasm", returns(bool))]
+    CanExecutorCommit {
+        dr_id:      String,
+        public_key: String,
+        commitment: String,
+        proof:      String,
+    },
+    #[cfg_attr(feature = "cosmwasm", returns(bool))]
+    CanExecutorReveal { dr_id: String, public_key: String },
     #[cfg_attr(feature = "cosmwasm", returns(Option<DataRequest>))]
     GetDataRequest { dr_id: String },
     #[cfg_attr(feature = "cosmwasm",  returns(Option<String>))]


### PR DESCRIPTION
## Motivation

This allows the chain to verify whether an incoming commit or reveal message is eligible for free gas.

## Explanation of Changes

The `CanExecutorCommit` has the same interface as the execution message, since on the chain side we only have that data available in order to check for eligibility.

## Testing

See contract PR.

## Related PRs and Issues

https://github.com/sedaprotocol/seda-chain-contracts/pull/248
