### PR TITLE
refactor: distribution payouts

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [features]

--- a/crates/common/src/msgs/data_requests/sudo/mod.rs
+++ b/crates/common/src/msgs/data_requests/sudo/mod.rs
@@ -24,7 +24,7 @@ pub struct DistributionBurn {
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
 #[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
-pub struct DistributionSend {
+pub struct DistributionDataProxyReward {
     /// The address to send the funds to.
     pub to:     Bytes,
     /// The amount to send to the address.
@@ -34,32 +34,22 @@ pub struct DistributionSend {
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
 #[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
-pub enum DistributionKind {
+pub enum DistributionMessage {
     /// For burning funds
     Burn(DistributionBurn),
     /// For rewarding an executor
     ExecutorReward(DistributionExecutorReward),
-    /// For sending the funds to someone
-    Send(DistributionSend),
+    /// For rewarding a data proxy
+    DataProxyReward(DistributionDataProxyReward),
 }
 
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
 #[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
-pub enum DistributionType {
-    TallyReward,
-    ExecutorReward,
-    TimedOut,
+pub enum RefundType {
+    Timeout,
     NoConsensus,
-    RemainderRefund,
-}
-#[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
-#[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
-#[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
-pub struct DistributionMessage {
-    pub kind:  DistributionKind,
-    #[serde(rename = "type")]
-    pub type_: DistributionType,
+    Remainder,
 }
 
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
@@ -67,7 +57,7 @@ pub struct DistributionMessage {
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub struct DistributionMessages {
     pub messages:    Vec<DistributionMessage>,
-    pub refund_type: DistributionType,
+    pub refund_type: RefundType,
 }
 
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]

--- a/crates/common/src/msgs/data_requests/sudo/mod.rs
+++ b/crates/common/src/msgs/data_requests/sudo/mod.rs
@@ -46,23 +46,6 @@ pub enum DistributionMessage {
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
 #[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
-pub enum RefundType {
-    Timeout,
-    NoConsensus,
-    Remainder,
-}
-
-#[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
-#[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
-#[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
-pub struct DistributionMessages {
-    pub messages:    Vec<DistributionMessage>,
-    pub refund_type: RefundType,
-}
-
-#[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
-#[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
-#[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub enum SudoMsg {
     RemoveDataRequests(remove_requests::Sudo),
     ExpireDataRequests(expire_data_requests::Sudo),

--- a/crates/common/src/msgs/data_requests/sudo/remove_requests.rs
+++ b/crates/common/src/msgs/data_requests/sudo/remove_requests.rs
@@ -6,7 +6,7 @@ use super::*;
 #[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub struct Sudo {
-    pub requests: HashMap<String, DistributionMessages>,
+    pub requests: HashMap<String, Vec<DistributionMessage>>,
 }
 
 impl From<Sudo> for crate::msgs::SudoMsg {

--- a/crates/common/src/msgs/data_requests/sudo_tests.rs
+++ b/crates/common/src/msgs/data_requests/sudo_tests.rs
@@ -19,8 +19,7 @@ fn json_remove_requests() {
     let expected_json = json!({
     "remove_data_requests": {
         "requests": {
-            "dr_id1": {
-                "messages": [
+            "dr_id1": [
                     {
                         "burn": {
                             "amount": "100"
@@ -39,50 +38,25 @@ fn json_remove_requests() {
                         },
                     }
                 ],
-                "refund_type": "remainder"
-            },
-            "dr_id2": {
-                "messages": [],
-                "refund_type": "timeout"
-            },
-            "dr_id3": {
-                "messages": [],
-                "refund_type": "no_consensus"
-            }
-        }
-    }});
+        },
+    }
+    });
     let mut requests = HashMap::new();
     requests.insert(
         "dr_id1".to_string(),
-        DistributionMessages {
-            messages:    vec![
-                DistributionMessage::Burn(DistributionBurn { amount: 100u128.into() }),
-                DistributionMessage::ExecutorReward(DistributionExecutorReward {
-                    amount:   100u128.into(),
-                    identity: "identity".to_string(),
-                }),
-                DistributionMessage::DataProxyReward(DistributionDataProxyReward {
-                    amount: 100u128.into(),
-                    to,
-                }),
-            ],
-            refund_type: RefundType::Remainder,
-        },
+        vec![
+            DistributionMessage::Burn(DistributionBurn { amount: 100u128.into() }),
+            DistributionMessage::ExecutorReward(DistributionExecutorReward {
+                amount:   100u128.into(),
+                identity: "identity".to_string(),
+            }),
+            DistributionMessage::DataProxyReward(DistributionDataProxyReward {
+                amount: 100u128.into(),
+                to,
+            }),
+        ],
     );
-    requests.insert(
-        "dr_id2".to_string(),
-        DistributionMessages {
-            messages:    vec![],
-            refund_type: RefundType::Timeout,
-        },
-    );
-    requests.insert(
-        "dr_id3".to_string(),
-        DistributionMessages {
-            messages:    vec![],
-            refund_type: RefundType::NoConsensus,
-        },
-    );
+
     let msg: msgs::SudoMsg = remove_requests::Sudo { requests }.into();
     #[cfg(not(feature = "cosmwasm"))]
     assert_json_ser(msg, expected_json);

--- a/crates/common/src/msgs/data_requests/sudo_tests.rs
+++ b/crates/common/src/msgs/data_requests/sudo_tests.rs
@@ -22,62 +22,65 @@ fn json_remove_requests() {
             "dr_id1": {
                 "messages": [
                     {
-                        "kind": {
-                            "burn": {
-                                "amount": "100"
-                            }
-                        },
-                        "type": "executor_reward"
+                        "burn": {
+                            "amount": "100"
+                        }
                     },
                     {
-                        "kind": {
-                            "executor_reward": {
-                                "amount": "100",
-                                "identity": "identity"
-                            }
-                        },
-                        "type": "executor_reward"
+                        "executor_reward": {
+                            "amount": "100",
+                            "identity": "identity"
+                        }
                     },
                     {
-                        "kind": {
-                            "send": {
-                                "amount": "100",
-                                "to": to
-                            }
+                        "data_proxy_reward": {
+                            "amount": "100",
+                            "to": to
                         },
-                        "type": "executor_reward"
                     }
                 ],
-                "refund_type": "remainder_refund"
+                "refund_type": "remainder"
             },
+            "dr_id2": {
+                "messages": [],
+                "refund_type": "timeout"
+            },
+            "dr_id3": {
+                "messages": [],
+                "refund_type": "no_consensus"
+            }
         }
-    }
-    });
+    }});
     let mut requests = HashMap::new();
     requests.insert(
         "dr_id1".to_string(),
         DistributionMessages {
             messages:    vec![
-                DistributionMessage {
-                    kind:  DistributionKind::Burn(DistributionBurn { amount: 100u128.into() }),
-                    type_: DistributionType::ExecutorReward,
-                },
-                DistributionMessage {
-                    kind:  DistributionKind::ExecutorReward(DistributionExecutorReward {
-                        amount:   100u128.into(),
-                        identity: "identity".to_string(),
-                    }),
-                    type_: DistributionType::ExecutorReward,
-                },
-                DistributionMessage {
-                    kind:  DistributionKind::Send(DistributionSend {
-                        amount: 100u128.into(),
-                        to,
-                    }),
-                    type_: DistributionType::ExecutorReward,
-                },
+                DistributionMessage::Burn(DistributionBurn { amount: 100u128.into() }),
+                DistributionMessage::ExecutorReward(DistributionExecutorReward {
+                    amount:   100u128.into(),
+                    identity: "identity".to_string(),
+                }),
+                DistributionMessage::DataProxyReward(DistributionDataProxyReward {
+                    amount: 100u128.into(),
+                    to,
+                }),
             ],
-            refund_type: DistributionType::RemainderRefund,
+            refund_type: RefundType::Remainder,
+        },
+    );
+    requests.insert(
+        "dr_id2".to_string(),
+        DistributionMessages {
+            messages:    vec![],
+            refund_type: RefundType::Timeout,
+        },
+    );
+    requests.insert(
+        "dr_id3".to_string(),
+        DistributionMessages {
+            messages:    vec![],
+            refund_type: RefundType::NoConsensus,
         },
     );
     let msg: msgs::SudoMsg = remove_requests::Sudo { requests }.into();


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Now that the chain has started working with this data, we have a better idea of how to format this data.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- `DistrbutionKind` has become `DistribtutionMessage` and no longer has the `type` field. The Message already knows the type so this is less verbose.
- `DistributionSend` -> `DistributionDataProxyReward` as this message is used to reward data proxies.
- `DistributionType` -> has been removed.
- The sudo request now takes a map of `dr_id` -> `Vec<DistributionMessage>`

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

JSON tests have been updated accordingly.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

This sets up https://github.com/sedaprotocol/seda-chain-contracts/issues/249 for the contract.
