### PR TITLE
Chore: proxy reward to as string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = ["crates/common", "crates/proto-common"]
 [workspace.dependencies]
 base64 = "0.22.1"
 cosmos-sdk-proto = { version = "0.26", default-features = false }
-cosmwasm-schema = "2.1"
-cosmwasm-std = "2.1"
+cosmwasm-schema = "2.2"
+cosmwasm-std = "2.2"
 cw-storage-plus = "2.0"
 hex = "0.4.3"
 k256 = "0.13"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [features]

--- a/crates/common/src/msgs/data_requests/sudo/mod.rs
+++ b/crates/common/src/msgs/data_requests/sudo/mod.rs
@@ -1,4 +1,4 @@
-use crate::types::{Bytes, U128};
+use crate::types::U128;
 
 pub mod expire_data_requests;
 pub mod remove_requests;
@@ -26,7 +26,7 @@ pub struct DistributionBurn {
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub struct DistributionDataProxyReward {
     /// The address to send the funds to.
-    pub to:     Bytes,
+    pub to:     String,
     /// The amount to send to the address.
     pub amount: U128,
 }

--- a/crates/common/src/msgs/data_requests/sudo/mod.rs
+++ b/crates/common/src/msgs/data_requests/sudo/mod.rs
@@ -26,9 +26,9 @@ pub struct DistributionBurn {
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub struct DistributionDataProxyReward {
     /// The address to send the funds to.
-    pub to:     String,
+    pub payout_address: String,
     /// The amount to send to the address.
-    pub amount: U128,
+    pub amount:         U128,
 }
 
 #[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]

--- a/crates/common/src/msgs/data_requests/sudo_tests.rs
+++ b/crates/common/src/msgs/data_requests/sudo_tests.rs
@@ -29,7 +29,7 @@ fn json_remove_requests() {
                     {
                         "data_proxy_reward": {
                             "amount": "100",
-                            "to": "to"
+                            "payout_address": "payout_address"
                         },
                     }
                 ],
@@ -46,8 +46,8 @@ fn json_remove_requests() {
                 identity: "identity".to_string(),
             }),
             DistributionMessage::DataProxyReward(DistributionDataProxyReward {
-                amount: 100u128.into(),
-                to:     "to".to_string(),
+                amount:         100u128.into(),
+                payout_address: "payout_address".to_string(),
             }),
         ],
     );

--- a/crates/common/src/msgs/data_requests/sudo_tests.rs
+++ b/crates/common/src/msgs/data_requests/sudo_tests.rs
@@ -3,19 +3,14 @@ use std::collections::HashMap;
 use serde_json::json;
 
 use super::sudo::*;
+use crate::msgs;
 #[cfg(feature = "cosmwasm")]
 use crate::msgs::assert_json_deser;
 #[cfg(not(feature = "cosmwasm"))]
 use crate::msgs::assert_json_ser;
-use crate::{msgs, types::Bytes};
 
 #[test]
 fn json_remove_requests() {
-    #[cfg(not(feature = "cosmwasm"))]
-    let to: Bytes = "to".to_string();
-    #[cfg(feature = "cosmwasm")]
-    let to: Bytes = "to".as_bytes().into();
-
     let expected_json = json!({
     "remove_data_requests": {
         "requests": {
@@ -34,7 +29,7 @@ fn json_remove_requests() {
                     {
                         "data_proxy_reward": {
                             "amount": "100",
-                            "to": to
+                            "to": "to"
                         },
                     }
                 ],
@@ -52,7 +47,7 @@ fn json_remove_requests() {
             }),
             DistributionMessage::DataProxyReward(DistributionDataProxyReward {
                 amount: 100u128.into(),
-                to,
+                to:     "to".to_string(),
             }),
         ],
     );


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To make it easier on the chain side.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Changed the to from Binary to a String, it still must be a valid address which is validated by the chain.
Also updated crate versions, the cosmwasm ones offer a performance impact, and makes future migrations easier(which I thought the latter might be nice to have before it goes to mainnet). 

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tests updated and they pass.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
